### PR TITLE
Enhance landing page style and copy

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -26,7 +26,7 @@ const inter = Inter({
   preload: true,
   fallback: ['system-ui', 'Arial', 'sans-serif'],
   adjustFontFallback: true,
-  weight: ['400', '500', '600', '700'], // Only load needed weights
+  weight: ['100', '200', '300', '400', '500', '600', '700'],
 })
 
 const jetbrainsMono = JetBrains_Mono({

--- a/src/components/Contact.js
+++ b/src/components/Contact.js
@@ -95,7 +95,7 @@ export default function Contact() {
         viewport={{ once: true, amount: 0.1 }}
       >
         <div className={styles.heading}>
-          <h2 className={styles.title}>Let's Start Your Project</h2>
+          <h2 className={styles.title}>Book a Build Session</h2>
           <p className={styles.subtitle}>
             Tell us about your project and we'll get back to you within 24 hours
           </p>
@@ -189,7 +189,7 @@ export default function Contact() {
                     <span className="animate-pulse">Sending...</span>
                   ) : (
                     <>
-                      <span>Start Your Project</span>
+                      <span>Book a Build Session</span>
                       <i className="bi bi-arrow-right"></i>
                     </>
                   )}

--- a/src/components/Features.js
+++ b/src/components/Features.js
@@ -155,7 +155,7 @@ export default function Features() {
           <span className={styles.sectionLabel}>What We Do</span>
           <h2 className={styles.gradientText}>Our Services</h2>
           <p className={styles.subtitle}>
-            Comprehensive solutions tailored to your digital needs in the crypto and blockchain space
+            A full‑stack arsenal for founders who actually ship
           </p>
         </motion.div>
 

--- a/src/components/Hero.js
+++ b/src/components/Hero.js
@@ -139,8 +139,7 @@ export default function Hero() {
           className={styles.heroSubheading}
           variants={fadeInUp}
         >
-          We craft Web3 & DeFi solutions for entrepreneurs and start-ups in the crypto space.
-          Our full-stack approach delivers secure, high-performance applications with stunning design.
+          We build Web3 products that impress investors and keep users coming back. Launch faster with airtight security and a sleek, modern UI.
         </motion.p>
 
         <motion.div

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -51,7 +51,7 @@ export default function Navbar({ isScrolled }) {
   ]
 
   return (
-    <header className={`${styles.navbar} ${isScrolled ? styles.scrolled : ''}`}>
+    <header className={`${styles.navbar} ${isScrolled ? styles.scrolled : ''} glassPanel`}>
       <div className={`container ${styles.container}`}>
         <Link href="/" className={styles.brand}>
           <div className={styles.logo}>

--- a/src/components/Tools.js
+++ b/src/components/Tools.js
@@ -44,27 +44,16 @@ export default function Tools() {
                   <div
                     className={styles.toolLogoContainer}
                   >
-                    {tool.logo.endsWith('.svg') ? (
-                      <img
-                        src={tool.logo}
-                        alt={`${tool.name} logo`}
-                        className={styles.toolLogo}
-                        loading="lazy"
-                        width={100}
-                        height={40}
-                        style={{ objectFit: 'contain' }}
-                      />
-                    ) : (
-                      <Image
-                        src={tool.logo}
-                        alt={`${tool.name} logo`}
-                        className={styles.toolLogo}
-                        width={100}
-                        height={40}
-                        style={{ objectFit: 'contain' }}
-                        quality={70}
-                      />
-                    )}
+                    <Image
+                      src={tool.logo}
+                      alt={`${tool.name} logo`}
+                      className={styles.toolLogo}
+                      width={100}
+                      height={40}
+                      style={{ objectFit: 'contain' }}
+                      quality={70}
+                      unoptimized={tool.logo.endsWith('.svg')}
+                    />
                   </div>
                   {<div className={styles.toolName}>{tool.name}</div>}
                 </div>

--- a/src/styles/component-css/Hero.module.css
+++ b/src/styles/component-css/Hero.module.css
@@ -227,7 +227,8 @@
   transform-style: preserve-3d;
   background-image: url(/images/gradients/g18.webp);
   background-size: cover;
-  background-repeat: no-repeat
+  background-repeat: no-repeat;
+  background-attachment: fixed;
 }
 
 .particlesContainer {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -376,6 +376,14 @@ a:hover {
   box-shadow: var(--shadow-sm)
 }
 
+.glassPanel {
+  background: var(--glass-bg);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--glass-shadow);
+}
+
 .gradient-text {
   background: var(--primary-gradient);
   background-clip: text;


### PR DESCRIPTION
## Summary
- refine hero copy
- update features subtitle
- adjust contact CTA
- convert tool logos to `next/image`
- apply glass panel style to navbar
- add glassPanel class and hero parallax effect
- broaden font weights for Inter

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68599807236883258cbfe1d0bace9060