### PR TITLE
Refresh site copy with millennial-friendly British tone

### DIFF
--- a/src/app/about/page.js
+++ b/src/app/about/page.js
@@ -61,22 +61,22 @@ export default function AboutPage() {
 
 
             <div className={styles.textContent}>
-              <p>At Flat 18, we specialise in delivering cutting-edge solutions in the ever-evolving realms of Bitcoin, cryptocurrency, and Web3 technologies. With over a decade of experience, Flat 18 LLC was officially established in 2017, built on a foundation of innovation, technical excellence, and commitment to quality. Our portfolio includes high-impact projects such as BTCPay Server and Wallet Scrutiny—initiatives that contribute meaningfully to the global crypto landscape. Additionally, we've developed Web3 solutions for international markets, including exchange and payment utilities for Nigeria's NairaEx. These are just a few examples of the transformative work we're proud to lead.</p>
+              <p>Flat 18 specialises in crafting forward‑thinking solutions across Bitcoin, cryptocurrency and Web3. With more than a decade in the game, Flat 18 LLC was formed in 2017 on a foundation of innovation, technical craft and obsessive quality. Our portfolio features high‑impact work like BTCPay Server and Wallet Scrutiny, plus Web3 tooling for global markets such as Nigeria’s NairaEx. These projects are just a glimpse of what we love to build.</p>
 
-              <h2>A Fearless Approach to Problem Solving</h2>
-              <p>At Flat 18, we believe that innovation thrives when fear is removed from the equation. This philosophy drives our approach to every project, whether we're creating advanced dashboards for veToken or custom payments processors for Bitcoin and Ethereum +ERC-20. We embrace challenges head-on, viewing obstacles as opportunities for growth and refinement. Our development process is agile yet meticulous, allowing us to adapt and respond swiftly while maintaining the high standards that ensure long-term reliability and success.</p>
+              <h2>Fearless problem solving</h2>
+              <p>At Flat 18 we reckon innovation happens when the fear comes out of the equation. Whether it’s dashboards for veToken or bespoke payment processors for Bitcoin and Ethereum + ERC‑20, we tackle challenges head-on and treat obstacles as chances to learn. Our process is agile, considered and always focused on long‑term reliability.</p>
 
-              <h2>Client-Centred Collaboration</h2>
-              <p>Building strong, trusting relationships with our clients is at the heart of Flat 18. Our development process is both collaborative and transparent, providing clients with as much or as little involvement as they prefer. Through the use of best-in-class tools, like Git for version control, we offer a seamless workflow where clients can stay informed and engaged at every step. We pride ourselves on delivering projects that not only meet but exceed expectations, ensuring satisfaction at every critical juncture. Our promise is to continuously refine our work until it reaches a level of perfection our clients expect.</p>
+              <h2>Collaboration that works for you</h2>
+              <p>Strong relationships sit at the heart of our work. We offer a collaborative and transparent development process where you can be as hands‑on or hands‑off as you like. Using tools like Git for version control, we keep you in the loop and deliver work that hits the mark at every step, refining until it’s spot on.</p>
 
-              <h2>Sophisticated and Scalable Solutions</h2>
-              <p>We believe in delivering solutions that are both sophisticated and scalable. Our approach leverages the best of modern technologies, from world-class serverless infrastructure to advanced software libraries. We are experts at maximising the efficiency of our builds, creating high-performance systems that are secure, resilient, and capable of scaling to meet your business's needs. Our curated selection of industry-leading platforms—like GitHub, Vercel, and Neon Postgres—ensures that each project is built on a robust and future-proof foundation, but never at the expense of quality or ambition.</p>
+              <h2>Built to scale</h2>
+              <p>We create solutions that are both sophisticated and ready to grow. By leaning on world‑class serverless infrastructure and tried‑and‑tested libraries we build high‑performance systems that are secure, resilient and primed for your business needs. Platforms like GitHub, Vercel and Neon Postgres give every project a future‑proof foundation without clipping its ambition.</p>
 
-              <h2>What Sets Flat 18 Apart</h2>
-              <p>Flat 18 is distinguished by our ability to deliver complex, high-value projects with a focus on craftsmanship and attention to detail. Our clients trust us to handle every element of their project, from the initial concept through to post-launch support, knowing that we'll deliver exceptional results every time. We specialise in working with cutting-edge technologies, including blockchain and Web3, and are committed to ensuring that every solution we provide is not only innovative but built to the highest industry standards. Our goal is to provide the level of service and expertise that lets our clients feel confident, whether they wish to be deeply involved or leave the finer details to us.</p>
+              <h2>Why choose Flat 18</h2>
+              <p>What sets us apart is our ability to deliver complex, high‑value projects with real craftsmanship. From concept to post‑launch support, clients trust us to handle every detail and to work with leading tech including blockchain and Web3. We’re committed to solutions that are innovative and built to the highest standard so you can feel confident whether you want to dive deep or leave the nitty‑gritty to us.</p>
 
-              <p>The future of technology is rich with potential, and Flat 18 is here to help you harness it.</p>
-              <p>Let's create something extraordinary together. ♥️☘️</p>
+              <p>The future of tech is full of potential and Flat 18 is here to help you tap into it.</p>
+              <p>Let’s build something brilliant together. ♥️☘️</p>
             </div>
           </motion.div>
         </motion.div>

--- a/src/components/Contact.js
+++ b/src/components/Contact.js
@@ -95,9 +95,9 @@ export default function Contact() {
         viewport={{ once: true, amount: 0.1 }}
       >
         <div className={styles.heading}>
-          <h2 className={styles.title}>Let's Talk About Your Project</h2>
+          <h2 className={styles.title}>Tell Us About Your Project</h2>
           <p className={styles.subtitle}>
-            Chat with us live or fill out the form—we'll reply within a day.
+            Jump on live chat or fill in the form — we'll get back within a day.
           </p>
         </div>
 
@@ -230,9 +230,9 @@ export default function Contact() {
           <div className={styles.visualElementGrid}></div>
           <div className={styles.visualElementContent}>
             <i className="bi bi-chat-square-text" style={{ fontSize: '3rem', marginBottom: '1rem', color: 'var(--secondary)' }}></i>
-            <h3 style={{ fontSize: '1.5rem', marginBottom: '1rem' }}>Let's Discuss Your Project</h3>
+            <h3 style={{ fontSize: '1.5rem', marginBottom: '1rem' }}>Let's chat about your project</h3>
             <p style={{ opacity: 0.8, maxWidth: '80%', margin: '0 auto' }}>
-              We're here to help turn your ideas into reality with our expertise in design and development.
+              We're here to turn your ideas into reality with our design and development know-how.
             </p>
           </div>
         </motion.div>

--- a/src/components/FAQ.js
+++ b/src/components/FAQ.js
@@ -146,8 +146,8 @@ export default function FAQ() {
         viewport={{ once: true, amount: 0.1 }}
       >
         <div className={styles.textOrg}>
-          <h2 className={styles.gradientText}>Commonly Asked Questions</h2>
-          <p className={styles.subtitle}>Find answers to common questions about our services</p>
+          <h2 className={styles.gradientText}>Frequently Asked Questions</h2>
+          <p className={styles.subtitle}>Answers to the bits we get asked the most</p>
         </div>
 
         <div className={styles.contentGrid}>
@@ -162,9 +162,9 @@ export default function FAQ() {
             <div className={styles.visualElementGrid}></div>
             <div className={styles.visualElementContent}>
               <i className="bi bi-question-circle" style={{ fontSize: '3rem', marginBottom: '1rem', color: 'var(--accent-yellow)' }}></i>
-              <h3 style={{ fontSize: '1.5rem', marginBottom: '1rem' }}>Still Have Questions?</h3>
+              <h3 style={{ fontSize: '1.5rem', marginBottom: '1rem' }}>Still have questions?</h3>
               <p style={{ opacity: 0.8, maxWidth: '80%', margin: '0 auto 1.5rem' }}>
-                We're here to help with any additional questions about your specific project needs.
+                We're here to help with anything else you'd like to know about your project.
               </p>
               <a href="#chat" style={{
                 display: 'inline-block',
@@ -186,7 +186,7 @@ export default function FAQ() {
               }}
               >
                 <i className="bi bi-chat-text" style={{ marginRight: '0.5rem' }}></i>
-                Chat With Us
+                Chat with us
               </a>
             </div>
           </motion.div>

--- a/src/components/Features.js
+++ b/src/components/Features.js
@@ -12,63 +12,63 @@ export default function Features() {
     {
       icon: 'bi-globe',
       title: 'Web Development',
-      description: 'Custom websites built with modern frameworks like Next.js, optimised for performance and SEO.',
+      description: 'Bespoke sites built with modern frameworks like Next.js, tuned for speed and search.',
       color: 'primary',
       learnMore: '/services/web-development'
     },
     {
       icon: 'bi-phone',
       title: 'App Development',
-      description: 'Scalable apps built with Node.js, reactive frameworks, and serverless backends.',
+      description: 'Scalable apps crafted with Node.js, reactive frameworks and serverless back-ends.',
       color: 'secondary',
       learnMore: '/services/app-development'
     },
     {
       icon: 'bi-palette',
       title: 'UI/UX Design',
-      description: 'Beautiful, intuitive interfaces designed with your users in mind.',
+      description: 'Clean, intuitive interfaces shaped around your users.',
       color: 'accent-purple',
       learnMore: '/services/ui-ux-design'
     },
     {
       icon: 'bi-lightbulb',
       title: 'AI Prompt Engineering',
-      description: 'Expertly crafted prompts to guide LLMs for consistent, high-quality outputs across content, code, and automation tasks.',
+      description: 'Expert prompts for LLMs to deliver consistent, high-quality content, code and automations.',
       color: 'secondary',
       learnMore: '/services/ai-prompt-engineering'
     },
     {
       icon: 'bi-cpu',
       title: 'AI-Augmented Development',
-      description: 'Accelerate your software delivery using AI-assisted code generation, validation, and refactoring workflows.',
+      description: 'Speed up delivery with AI-assisted code generation, reviews and refactors.',
       color: 'accent-teal',
       learnMore: '/services/ai-augmented-development'
     },
     {
       icon: 'bi-brush',
       title: 'AI-Seeded Design & Graphics',
-      description: 'Visual design powered by generative AI—creative concepts, layout proposals, and high-resolution assets informed by your brand.',
+      description: 'Generative AI to spark visuals, layouts and high-res assets guided by your brand.',
       color: 'accent-purple',
       learnMore: '/services/ai-seeded-design'
     },
     {
       icon: 'bi-shield-lock',
       title: 'Web3 & Blockchain',
-      description: 'Smart contract development, wallet integration, and decentralised apps tailored for the blockchain ecosystem.',
+      description: 'Smart contracts, wallet integrations and decentralised apps built for the blockchain world.',
       color: 'accent-teal',
       learnMore: '/services/web3-blockchain'
     },
     {
       icon: 'bi-code-slash',
       title: 'API Integration',
-      description: 'Seamless integration with third-party services and bespoke API development.',
+      description: 'Seamless integrations with third‑party services and custom APIs.',
       color: 'accent-pink',
       learnMore: '/services/api-integration'
     },
     {
       icon: 'bi-gear',
       title: 'Maintenance & Support',
-      description: '24/7 technical support and regular updates to keep your digital assets running smoothly.',
+      description: 'Ongoing support and updates so your digital assets keep ticking over.',
       color: 'accent-yellow',
       learnMore: '/services/maintenance-support'
     }
@@ -155,7 +155,7 @@ export default function Features() {
           <span className={styles.sectionLabel}>What We Do</span>
           <h2 className={styles.gradientText}>Our Services</h2>
           <p className={styles.subtitle}>
-            Comprehensive solutions tailored to your digital needs in the crypto and blockchain space
+            Everything you need to build and scale web, app and blockchain projects
           </p>
         </motion.div>
 
@@ -198,7 +198,7 @@ export default function Features() {
           variants={headingVariants}
         >
           <a href="#chat" className={styles.ctaButton}>
-            <span>Discuss Your Project</span>
+            <span>Tell Us About Your Project</span>
             <i className="bi bi-arrow-right"></i>
           </a>
         </motion.div>

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -14,7 +14,7 @@ export default function Footer() {
             <Link href="/" className={styles.footerBrand} aria-label="Flat 18 Home">
               <div className={styles.footerLogo}>F18</div>
             </Link>
-            <p className={styles.footerTagline}>Modern web development for crypto & blockchain projects</p>
+            <p className={styles.footerTagline}>High-impact web and app builds for crypto and beyond</p>
           </div>
 
           <div className={styles.footerContent}>

--- a/src/components/Hero.js
+++ b/src/components/Hero.js
@@ -115,7 +115,7 @@ export default function Hero() {
         </h1>
 
         <div className={styles.badgeBanner}>
-          ⬤ Currently Taking Projects – Book Your Slot Now
+          ⬤ Now taking on new projects – claim your spot today
         </div>
 
         {/* Main heading with updated content */}
@@ -129,8 +129,8 @@ export default function Hero() {
           className={styles.heroSubheading}
           variants={fadeInUp}
         >
-          We help founders launch real products — from MVPs to scalable platforms — quickly and without compromise.<br />
-          Secure. Performant. Beautiful. Let’s bring your vision to life.
+          We help founders launch proper products – from MVPs to full platforms – fast and without the faff.<br />
+          Secure, speedy and stunning. Let’s bring your idea to life.
         </motion.p>
 
         <motion.div
@@ -139,7 +139,7 @@ export default function Hero() {
         >
           <motion.div variants={buttonVariants} whileHover="hover" whileTap="tap">
             <Link href="#contact" className={`${styles.primaryButton} btn-icon`}>
-              <span className={styles.btnText}>Plan Your Build</span>
+              <span className={styles.btnText}>Start Your Build</span>
               <span className={styles.btnIcon}><i className="bi bi-arrow-right"></i></span>
               <span className={styles.btnGlow}></span>
             </Link>
@@ -147,7 +147,7 @@ export default function Hero() {
 
           <motion.div variants={secondaryButtonVariants} whileHover="hover" whileTap="tap">
             <Link href="#work" className={styles.secondaryButton}>
-              <span className={styles.btnText}>See What We’ve Built</span>
+              <span className={styles.btnText}>See Our Work</span>
               <span className={styles.btnGlow}></span>
             </Link>
           </motion.div>
@@ -166,7 +166,7 @@ export default function Hero() {
             whileHover="hover"
           >
             <div className={styles.statNumber}>12+</div>
-            <div className={styles.statLabel}>Years in Product Development</div>
+            <div className={styles.statLabel}>Years in product development</div>
             <div className={styles.statGlow}></div>
           </motion.div>
 
@@ -176,7 +176,7 @@ export default function Hero() {
             whileHover="hover"
           >
             <div className={styles.statNumber}>20+</div>
-            <div className={styles.statLabel}>Projects Launched</div>
+            <div className={styles.statLabel}>Projects shipped</div>
             <div className={styles.statGlow}></div>
           </motion.div>
 
@@ -186,7 +186,7 @@ export default function Hero() {
             whileHover="hover"
           >
             <div className={styles.statNumber}>100%</div>
-            <div className={styles.statLabel}>Client Satisfaction</div>
+            <div className={styles.statLabel}>Happy clients</div>
             <div className={styles.statGlow}></div>
           </motion.div>
         </motion.div>

--- a/src/components/HowItWorks.js
+++ b/src/components/HowItWorks.js
@@ -10,9 +10,9 @@ export default function HowItWorks() {
       number: '01',
       title: 'Discover',
       icon: 'bi-chat-dots',
-      description: 'We begin with a discovery session to understand your project needs, goals, and timeline. This enables us to create a tailored development plan that aligns with your vision.',
+      description: 'Kick off with a quick discovery chat to map out your goals and timeline. We’ll craft a plan that fits your vision.',
       link: {
-        text: 'Start a Discovery session',
+        text: 'Book a discovery chat',
         href: '#chat',
         icon: 'bi-arrow-right'
       }
@@ -21,14 +21,14 @@ export default function HowItWorks() {
       number: '02',
       title: 'Develop',
       icon: 'bi-code-slash',
-      description: 'Our team of experts builds your project with regular updates and transparent communication. We use modern technologies and best practices to ensure high-quality results.',
+      description: 'We build in the open with regular updates and clear comms, using modern tech and best practice to keep quality high.',
 
     },
     {
       number: '03',
       title: 'Deliver',
       icon: 'bi-rocket-takeoff',
-      description: 'We deliver initial samples within 2–3 days, with subsequent requests completed within 48 hours. Our iterative approach ensures you are satisfied with the final product.',
+      description: 'Expect first samples in 2–3 days and follow-ups inside 48 hours. Iteration keeps things on track until you’re thrilled with the result.',
       link: {
         text: 'See our past work',
         href: '#work',
@@ -76,7 +76,7 @@ export default function HowItWorks() {
         <div className={styles.sectionHeading}>
           <h2 className={styles.sectionTitle}>How We Work</h2>
           <p className={styles.sectionSubtitle}>
-            Our streamlined process delivers exceptional results with maximum efficiency
+            Our no-fuss process keeps quality high and momentum strong
           </p>
         </div>
 

--- a/src/components/Portfolio.js
+++ b/src/components/Portfolio.js
@@ -508,7 +508,7 @@ export default function Portfolio() {
           <span className={styles.sectionLabel}>Portfolio</span>
           <h2 className={styles.portfolioTitle}>Our Work</h2>
           <p className={styles.portfolioSubtitle}>
-            Explore our portfolio of successful projects across web and blockchain applications.
+            Take a peek at some of the sites and apps we've shipped across web and blockchain.
           </p>
 
           <div className={styles.filterContainer}>

--- a/src/components/Pricing.js
+++ b/src/components/Pricing.js
@@ -161,7 +161,7 @@ export default function Pricing() {
       <div className="container">
         <div className={styles.pricingHeading}>
           <h2 className="gradient-text">Pricing. Simple.</h2>
-          <p>Transparent, value-based pricing for your digital projects</p>
+          <p>Straightforward pricing built for growing ideas</p>
         </div>
         
         <div className={styles.currencyDropdown}>
@@ -216,9 +216,9 @@ export default function Pricing() {
                 <div className={styles.switchIndicator}></div>
               </div>
               <div className={styles.switchLabel}>
-                {billingPeriod === 'quarterly' 
-                  ? `You're saving ${prices.monthlySavings[selectedCurrency] || prices.monthlySavings.GBP} with quarterly billing`
-                  : `Billed Monthly. Activate savings with quarterly billing`
+                {billingPeriod === 'quarterly'
+                  ? `You're saving ${prices.monthlySavings[selectedCurrency] || prices.monthlySavings.GBP} on the quarterly plan`
+                  : `Billed monthly. Switch to quarterly and save`
                 }
               </div>
             </div>
@@ -230,19 +230,19 @@ export default function Pricing() {
               <ul className={styles.featuresList}>
                 <li className={styles.featureItem}>
                   <i className={`bi bi-check-circle-fill ${styles.featureIcon}`}></i>
-                  <span className={styles.featureText}>Queued Tasks delivered in as little as 48hrs</span>
+                  <span className={styles.featureText}>Queued tasks turned around in as little as 48 hours</span>
                 </li>
                 <li className={styles.featureItem}>
                   <i className={`bi bi-check-circle-fill ${styles.featureIcon}`}></i>
-                  <span className={styles.featureText}>Unlimited Development Scopes</span>
+                  <span className={styles.featureText}>Unlimited development scopes</span>
                 </li>
                 <li className={styles.featureItem}>
                   <i className={`bi bi-check-circle-fill ${styles.featureIcon}`}></i>
-                  <span className={styles.featureText}>Application staging</span>
+                  <span className={styles.featureText}>Application staging included</span>
                 </li>
                 <li className={styles.featureItem}>
                   <i className={`bi bi-check-circle-fill ${styles.featureIcon}`}></i>
-                  <span className={styles.featureText}>Unlimited Revisions queue</span>
+                  <span className={styles.featureText}>Unlimited revision queue</span>
                 </li>
               </ul>
             </div>
@@ -259,7 +259,7 @@ export default function Pricing() {
                     <li className={styles.featureItem}>
                       <i className={`bi bi-credit-card ${styles.featureIcon}`}></i>
                       <span className={styles.featureText}>
-                        Pre-pay {prices.monthly[selectedCurrency] || prices.monthly.GBP} every month
+                        Pre-pay {prices.monthly[selectedCurrency] || prices.monthly.GBP} each month
                       </span>
                     </li>
                   </>
@@ -272,7 +272,7 @@ export default function Pricing() {
                     <li className={styles.featureItem}>
                       <i className={`bi bi-piggy-bank ${styles.featureIcon}`}></i>
                       <span className={styles.featureText}>
-                        Save {prices.monthlySavings[selectedCurrency] || prices.monthlySavings.GBP} vs monthly
+                        Save {prices.monthlySavings[selectedCurrency] || prices.monthlySavings.GBP} compared with monthly
                       </span>
                     </li>
                     <li className={styles.featureItem}>
@@ -290,11 +290,11 @@ export default function Pricing() {
         
         <div className={styles.pricingActions}>
           <Link href="/pricing#more-info" className={styles.linkLight}>
-            <span>Learn more</span>
+            <span>Find out more</span>
             <i className="bi bi-arrow-right ms-2"></i>
           </Link>
           <Link href="#chat" className="btn btn-primary">
-            <span>Let's talk about pricing</span>
+            <span>Let's chat about pricing</span>
           </Link>
         </div>
       </div>

--- a/src/components/Stats.js
+++ b/src/components/Stats.js
@@ -65,10 +65,10 @@ export default function Stats() {
   }, [])
 
   const stats = [
-    { value: 20, label: 'Projects Completed' },
-    { value: 100, label: 'Client Satisfaction', symbol:'%' },
-    { value: 12, label: 'Years Experience' },
-    { value: '2', label: 'Team Members\n(Yes, really)', noPlus: true }
+    { value: 20, label: 'Projects shipped' },
+    { value: 100, label: 'Happy clients', symbol:'%' },
+    { value: 12, label: 'Years in the game' },
+    { value: '2', label: 'Team members\n(yes, really)', noPlus: true }
   ]
 
   return (

--- a/src/components/Testimonials.js
+++ b/src/components/Testimonials.js
@@ -384,7 +384,7 @@ export default function Testimonials() {
           <span className={styles.sectionTag}>Testimonials</span>
           <h2 className={styles.sectionTitle}>What Our Clients Say</h2>
           <p className={styles.sectionSubtitle}>
-            Hear from the entrepreneurs and founders who have trusted us with their digital vision
+            Hear from founders who’ve trusted us with their digital vision
           </p>
         </motion.div>
 

--- a/src/components/Tools.js
+++ b/src/components/Tools.js
@@ -27,8 +27,8 @@ export default function Tools() {
     <section className={styles.toolsSection}>
       <div className="container">
         <div className={styles.toolsHeader}>
-          <h2 className={styles.toolsTitle}>Technologies We Use</h2>
-          <p className={styles.toolsSubtitle}>Modern tools for modern solutions</p>
+          <h2 className={styles.toolsTitle}>Tools We Trust</h2>
+          <p className={styles.toolsSubtitle}>Best-in-class tech for every build</p>
         </div>
 
         <div className={styles.toolsContainer}>


### PR DESCRIPTION
## Summary
- Rewrite hero messaging and CTAs for a friendlier, high-conversion feel
- Revamp service descriptions, pricing info and contact copy in standard British English
- Update about and FAQ pages with millennial-friendly tone while preserving factual details

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68901178a0308325a05270eb82def24f